### PR TITLE
Reimplement-matches-component

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -6,7 +6,7 @@ const angular = require("angular-eslint");
 
 module.exports = tseslint.config(
   {
-    ignores: [".amplify/", "dist/"],
+    ignores: [".amplify/", ".angular/", "dist/"],
   },
   {
     files: ["**/*.ts"],

--- a/src/app/matches/matches.component.html
+++ b/src/app/matches/matches.component.html
@@ -3,7 +3,7 @@
   <h1>My matches</h1>
   <button (click)="createMatch()">+ new</button>
   <ul>
-    @for (match of matches; track match.id) {
+    @for (match of matches | async; track match.id) {
     <li>
       <span>{{ match.teamHome }} - {{ match.teamAway }} - {{ match.startTime | date:'long' }}</span>
       <button (click)="deleteMatch(match.id)">X</button>


### PR DESCRIPTION
Improvements:
- Only one subscription for listing matches is created. Previously
  creating a new match also created new subscription. Subscription
  is properly disconnected when component is destroyed by using
  AsyncPipe.
- Properly use await for creating and deleting matches
- Use ChangeDetectionStrategy.OnPush to avoid Angular from eagerly
  checking for changes.

AFAIK, there should be a Service between the component and backend
handling the client and retries etc. Adding that is left for future.