### PR TITLE
Remove @eslint/compat dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "@angular/compiler-cli": "^18.2.6",
         "@aws-amplify/backend": "^1.3.0",
         "@aws-amplify/backend-cli": "^1.2.8",
-        "@eslint/compat": "^1.1.1",
         "@types/jasmine": "~5.1.0",
         "angular-eslint": "^18.2.0",
         "aws-cdk": "^2.160.0",
@@ -15862,15 +15861,6 @@
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@eslint/compat": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.1.1.tgz",
-      "integrity": "sha512-lpHyRyplhGPL5mGEh6M9O5nnKk0Gz4bFI+Zu6tKlPpDUN7XshWvH9C/px4UVm87IAANE0W81CEsNGbS1KlzXpA==",
-      "dev": true,
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/config-array": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@angular/compiler-cli": "^18.2.6",
     "@aws-amplify/backend": "^1.3.0",
     "@aws-amplify/backend-cli": "^1.2.8",
-    "@eslint/compat": "^1.1.1",
     "@types/jasmine": "~5.1.0",
     "angular-eslint": "^18.2.0",
     "aws-cdk": "^2.160.0",


### PR DESCRIPTION
Everything seems to work without it so this project is likely not relying on eslint plugins that wouldn't support eslint 9 properly.