### PR TITLE
Disable angular-eslint check no-call-expression

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -60,6 +60,7 @@ export default tseslint.config(
     ],
     rules: {
       "@angular-eslint/template/i18n": ["off"],
+      "@angular-eslint/template/no-call-expression": ["off"],
     },
   },
 );


### PR DESCRIPTION
This check causes false positive errors on newer angular-eslint versions. Disable it for now.