### PR TITLE
Fix amplify deployment

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -23,6 +23,12 @@ packageExtensions:
       "@aws-sdk/types": ^3.609.0
       zod: ^3.22.2
   "@aws-amplify/backend-auth@~1.3.0":
+    dependencies:
+      # Add missing peer dependency to platform-core.
+      # Visible: yarn exec amplify sandbox --once
+      # Note: Listed only as dev dependency
+      #   https://yarnpkg.com/package?q=%40aws-amplify%2Fbackend-auth&name=%40aws-amplify%2Fbackend-auth&version=1.3.0&file=%2Fpackage.json
+      "@aws-amplify/platform-core": "^1.0.6"
     peerDependencies:
       "@aws-sdk/types": ^3.609.0
       zod: ^3.22.2
@@ -36,7 +42,16 @@ packageExtensions:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
       typescript: ^5.0.0
+      # Add missing peer dependency to tsx
+      # Note: See comment for @aws-amplify/backend-deployer
+      tsx: "^4.6.1"
   "@aws-amplify/backend-data@~1.1.7":
+    dependencies:
+      # Add missing peer dependency to platform-core.
+      # Visible: yarn exec amplify sandbox --once
+      # Note: Listed only as dev dependency
+      #   https://yarnpkg.com/package?q=%40aws-amplify%2Fbackend-data&name=%40aws-amplify%2Fbackend-data&version=1.1.7&file=%2Fpackage.json
+      "@aws-amplify/platform-core": "^1.2.0"
     peerDependencies:
       "@aws-sdk/types": ^3.609.0
       zod: ^3.22.2
@@ -45,7 +60,19 @@ packageExtensions:
       "@aws-sdk/types": ^3.609.0
       aws-cdk-lib: ^2.158.0
       constructs: ^10.0.0
+      # Add missing peer dependency to tsx
+      # Visible: yarn exec amplify sandbox --once
+      # Note: backend-deployer executes "yarn tsx ..." assuming tsx is
+      #   top-level dependency. It is currently listed as dependency. But
+      #   listing it as peer dependency through its dependency chain is needed.
+      tsx: "^4.6.1"
   "@aws-amplify/backend-function@~1.7.4":
+    dependencies:
+      # Add missing peer dependency to platform-core.
+      # Visible: yarn exec amplify sandbox --once
+      # Note: Listed only as dev dependency
+      #   https://yarnpkg.com/package?q=%40aws-amplify%2Fbackend-function&name=%40aws-amplify%2Fbackend-function&version=1.7.4&file=%2Fpackage.json
+      "@aws-amplify/platform-core": "^1.1.0"
     peerDependencies:
       "@aws-sdk/types": ^3.609.0
       zod: ^3.22.2
@@ -60,6 +87,12 @@ packageExtensions:
       aws-cdk-lib: ^2.158.0
       constructs: ^10.0.0
   "@aws-amplify/backend-storage@~1.2.2":
+    dependencies:
+      # Add missing peer dependency to platform-core.
+      # Visible: yarn exec amplify sandbox --once
+      # Note: Listed only as dev dependency
+      #   https://yarnpkg.com/package?q=%40aws-amplify%2Fbackend-storage&name=%40aws-amplify%2Fbackend-storage&version=1.2.2&file=%2Fpackage.json
+      "@aws-amplify/platform-core": "^1.0.6"
     peerDependencies:
       "@aws-sdk/types": ^3.609.0
       zod: ^3.22.2
@@ -90,6 +123,21 @@ packageExtensions:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
   "@aws-amplify/graphql-conversation-transformer@0.6.0":
+    dependencies:
+      # Add missing dependency to fs-extra
+      # Visible: yarn exec amplify sandbox --once
+      # Note: Not specified as any dependency
+      #   https://yarnpkg.com/package?q=%40aws-amplify%2Fgraphql-conversation-transformer&name=%40aws-amplify%2Fgraphql-conversation-transformer&version=0.6.0&file=%2Fpackage.json
+      #   fs-extra version ^8.1.0 is selected based on
+      #   https://github.com/search?q=repo%3Aaws-amplify%2Famplify-category-api+fs-extra+language%3AJSON&type=code
+      fs-extra: ^8.1.0
+      # Add missing dependency to pluralize
+      # Visible: yarn exec amplify sandbox --once
+      # Note: Not specified as any dependency
+      #   https://yarnpkg.com/package?q=%40aws-amplify%2Fgraphql-conversation-transformer&name=%40aws-amplify%2Fgraphql-conversation-transformer&version=0.6.0&file=%2Fpackage.json
+      #   Pluralize version ^8.0.0 is selected based on
+      #   https://github.com/search?q=repo%3Aaws-amplify%2Famplify-category-api+pluralize+language%3AJSON&type=code&l=JSON
+      pluralize: ^8.0.0
     peerDependencies:
       "@aws-sdk/types": ^3.609.0
       zod: ^3.22.2
@@ -97,6 +145,22 @@ packageExtensions:
     peerDependencies:
       aws-cdk-lib: ^2.158.0
       constructs: ^10.3.0
+  "@aws-amplify/graphql-index-transformer@~3.0.8":
+    dependencies:
+      # Add missing dependency to pluralize
+      # Visible: yarn exec amplify sandbox --once
+      # Note: Not specified as any dependency
+      #   https://yarnpkg.com/package?q=%40aws-amplify%2Fgraphql-index&name=%40aws-amplify%2Fgraphql-index-transformer&version=3.0.8&file=%2Fpackage.json
+      #   Pluralize version ^8.0.0 is selected based on
+      #   https://github.com/search?q=repo%3Aaws-amplify%2Famplify-category-api+pluralize+language%3AJSON&type=code&l=JSON
+      pluralize: ^8.0.0
+  "@aws-amplify/graphql-maps-to-transformer@~4.0.8":
+    dependencies:
+      # Add missing dependency to graphql
+      # Visible: yarn exec amplify sandbox --once
+      # Note: Only listed as dev dependency
+      #   https://yarnpkg.com/package?q=%40aws-amplify%2Fgraphql-maps-to-transformer&name=%40aws-amplify%2Fgraphql-maps-to-transformer&version=4.0.8&file=%2Fpackage.json
+      graphql: ^15.5.0
   "@aws-amplify/graphql-schema-generator@0.11.1":
     peerDependencies:
       aws-cdk-lib: ^2.158.0
@@ -125,6 +189,9 @@ packageExtensions:
       aws-cdk-lib: ^2.158.0
       constructs: ^10.0.0
       typescript: ^5.0.0
+      # Add missing peer dependency to tsx
+      # Note: See comment for @aws-amplify/backend-deployer
+      tsx: "^4.6.1"
   "@aws-amplify/schema-generator@~1.2.5":
     peerDependencies:
       "@aws-sdk/types": ^3.609.0

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "prettier": "3.3.3",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "tsx": "4.19.2",
     "typescript": "5.5.4",
     "typescript-eslint": "8.14.0",
     "zod": "3.23.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17921,6 +17921,7 @@ __metadata:
     react-dom: "npm:18.3.1"
     rxjs: "npm:7.8.1"
     tslib: "npm:2.8.1"
+    tsx: "npm:4.19.2"
     typescript: "npm:5.5.4"
     typescript-eslint: "npm:8.14.0"
     zod: "npm:3.23.8"
@@ -18044,7 +18045,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsx@npm:^4.6.1":
+"tsx@npm:4.19.2, tsx@npm:^4.6.1":
   version: 4.19.2
   resolution: "tsx@npm:4.19.2"
   dependencies:


### PR DESCRIPTION
Running "yarn exec amplify sandbox --once" performs several operations
including cdk synthetization and cdk deployment. These revealed few
errors from imports that aren't listed as dependencies and command
executions of commands that aren't ensured to be available like that.
This commits fixes such dependencies with yarns packageExtensions.

These fixes hopefully also enable Amplify deployment in AWS to work.