### PR TITLE
mend: Adjust angular major update group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,7 +29,6 @@
         "monorepo:angular-cli",
         "monorepo:angular-eslint",
       ],
-      matchPackageNames: ["zone.js"],
       matchUpdateTypes: ["major"],
       dependencyDashboardApproval: true,
       groupName: "major-angular",


### PR DESCRIPTION
The rule doesn't seem to function like intended so try removing zone.js from the group. It doesn't have major version updates anyway so having it there doesn't bring real benefits.