### PR TITLE
ci: Better yarn install json output

### DIFF
--- a/.github/workflows/check-yarn.yaml
+++ b/.github/workflows/check-yarn.yaml
@@ -47,7 +47,7 @@ jobs:
         uses: ./.github/actions/yarn-project-setup
       - name: Yarn install output check
         run: |
-          errors=$(yarn install --json | jq 'select(.displayName != "YN0000")')
+          errors=$(FORCE_COLOR=0 yarn install --json | jq 'select(.displayName != "YN0000")')
           error_count=$(echo "$errors" | jq -s 'length')
           if [ "$error_count" -gt 0 ]; then
             echo "Detected Yarn install errors: $error_count"


### PR DESCRIPTION
Disable colored yarn output when capturing it as json. This removes also terminal formatting codes from the json output making the output from the job easier to read.