### PR TITLE
ci: Attempt to colorize yarn install check output

### DIFF
--- a/.github/workflows/check-yarn.yaml
+++ b/.github/workflows/check-yarn.yaml
@@ -47,10 +47,10 @@ jobs:
         uses: ./.github/actions/yarn-project-setup
       - name: Yarn install output check
         run: |
-          errors=$(FORCE_COLOR=0 yarn install --json | jq 'select(.displayName != "YN0000")')
+          errors=$(yarn install --json | jq 'select(.displayName != "YN0000")')
           error_count=$(echo "$errors" | jq -s 'length')
           if [ "$error_count" -gt 0 ]; then
             echo "Detected Yarn install errors: $error_count"
-            echo "$errors"
+            echo -e "$errors"
             exit 1
           fi


### PR DESCRIPTION
FORCE_COLOR=0 did not cause same behavior in Github actions as it did locally. And it seems that `echo -e` makes the echo to interpret the coloring escape symbols in the contained string which should be the best possible output format.