### PR TITLE
ci: Reorder yarn check jobs

### DIFF
--- a/.github/workflows/check-yarn.yaml
+++ b/.github/workflows/check-yarn.yaml
@@ -23,20 +23,6 @@ jobs:
       - name: Check for duplicate dependencies
         run: yarn run check:yarn:dedupe
 
-  peer-requirements:
-    name: Validate yarn peer requirements
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - name: Setup project
-        uses: ./.github/actions/yarn-project-setup
-      - name: Validate peer requirements are defined
-        run: |
-          reqs=$(yarn explain peer-requirements)
-          echo "$reqs" | grep '✘' || true
-          echo "$reqs" | grep -q '✘' && exit 1 || exit 0
-
   yarn-install-errors:
     name: Validate Yarn install does not contain errors
     runs-on: ubuntu-latest
@@ -54,3 +40,17 @@ jobs:
             echo -e "$errors"
             exit 1
           fi
+
+  peer-requirements:
+    name: Validate yarn peer requirements
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Setup project
+        uses: ./.github/actions/yarn-project-setup
+      - name: Validate peer requirements are defined
+        run: |
+          reqs=$(yarn explain peer-requirements)
+          echo "$reqs" | grep '✘' || true
+          echo "$reqs" | grep -q '✘' && exit 1 || exit 0


### PR DESCRIPTION
The install output check job should listed in the job listing above
the peer requirements job. The install output job will contain output
whenever the peer requirements job would show something and then the
peer requirements jobs contains extra details of what is wrong with the
peer requirements.